### PR TITLE
Don't fail on closing not yet started source.

### DIFF
--- a/lib/em-eventsource.rb
+++ b/lib/em-eventsource.rb
@@ -87,7 +87,7 @@ module EventMachine
     # Cancel subscription
     def close
       @ready_state = CLOSED
-      @req.close
+      @req.close if @req
     end
 
     protected

--- a/spec/em-eventsource_spec.rb
+++ b/spec/em-eventsource_spec.rb
@@ -189,4 +189,8 @@ describe EventMachine::EventSource do
     end
   end
 
+  it "doesn't fail when trying to close not yet started source" do
+    EventMachine::EventSource.new("").close
+  end
+
 end


### PR DESCRIPTION
I have a situation when I want to close an EventSource in a callback. The fun fact is that callback could be fired before the EventSource was actually started. I believe dealing with such situation belongs to the EventSource object. Please correct me if I'm wrong.
