### PR TITLE
Call #close for the HTTP connection, not the request

### DIFF
--- a/lib/em-eventsource.rb
+++ b/lib/em-eventsource.rb
@@ -87,13 +87,13 @@ module EventMachine
     # Cancel subscription
     def close
       @ready_state = CLOSED
-      @req.close if @req
+      @conn.close('requested') if @conn
     end
 
     protected
 
     def listen
-      @req = prepare_request
+      @conn, @req = prepare_request
       @req.errback do
         next if @ready_state == CLOSED
         @ready_state = CONNECTING
@@ -164,8 +164,8 @@ module EventMachine
       }
       headers = @headers.merge({'Cache-Control' => 'no-cache'})
       headers.merge!({'Last-Event-Id' => @last_event_id }) if not @last_event_id.nil?
-      conn.get({ :query => @query,
-                 :head  => headers})
+      [conn, conn.get({ :query => @query,
+                        :head  => headers})]
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ module EventMachine
       @headers.each { |header| header.call(headers) }
     end
 
-    def close
+    def close(reason)
       # do nothing
     end
   end


### PR DESCRIPTION
Otherwise the connection doesn't really get closed, and you'll receive events even after calling #close for the source.

A bug related to this was fixed in em-http-request's master branch just recently:
https://github.com/igrigorik/em-http-request/issues/184
