### PR TITLE
Changed behavior on a non-200 response so that we will reconnect

### DIFF
--- a/lib/em-eventsource.rb
+++ b/lib/em-eventsource.rb
@@ -107,6 +107,14 @@ module EventMachine
       @conn.close('requested') if @conn
     end
 
+    # Gracefully reconnect
+    def reconnect
+      close
+      EM.add_timer(@retry) do
+        start
+      end
+    end
+
     protected
 
     def listen
@@ -136,7 +144,7 @@ module EventMachine
 
     def handle_headers(headers)
       if headers.status != 200
-        close
+        reconnect
         @errors.each { |error| error.call("Unexpected response status #{headers.status}") }
         return
       end


### PR DESCRIPTION
We use a proxy to make our "server" side highly available, when there is a temporary backend issue it returns a non-200 status code and it seems like rather than giving up we should just create it like any other connection error and reconnect after retry.

Thoughts?
