### PR TITLE
recover named messages which are lost with no handler

### DIFF
--- a/lib/em-eventsource.rb
+++ b/lib/em-eventsource.rb
@@ -170,10 +170,10 @@ module EventMachine
       end
       return if data.empty?
       data.chomp!
-      if name.nil?
-        @messages.each { |message| message.call(data) }
+      if @on[name].nil?
+         @messages.each { |message| message.call(data) }
       else
-        @on[name].each { |message| message.call(data) } if not @on[name].nil?
+        @on[name].each { |message| message.call(data) } 
       end
     end
 

--- a/lib/em-eventsource.rb
+++ b/lib/em-eventsource.rb
@@ -171,7 +171,7 @@ module EventMachine
       return if data.empty?
       data.chomp!
       if @on[name].nil?
-         @messages.each { |message| message.call(data) }
+         @messages.each { |name, message| message.call(name, data) }
       else
         @on[name].each { |message| message.call(data) } 
       end

--- a/lib/em-eventsource.rb
+++ b/lib/em-eventsource.rb
@@ -171,7 +171,7 @@ module EventMachine
       return if data.empty?
       data.chomp!
       if @on[name].nil?
-         @messages.each { |name, message| message.call(name, data) }
+         @messages.each { |message| message.call(name, data) }
       else
         @on[name].each { |message| message.call(data) } 
       end

--- a/spec/em-eventsource_spec.rb
+++ b/spec/em-eventsource_spec.rb
@@ -98,7 +98,7 @@ describe EventMachine::EventSource do
     context "with #{eol_desc} EOL" do
       it "connect and handle message" do
         start_source do |source, req|
-          source.message do |message|
+          source.message do |name, message|
             message.must_equal "hello world"
             source.close
             EM.stop
@@ -109,7 +109,7 @@ describe EventMachine::EventSource do
 
       it "handle multiple messages" do
         start_source do |source, req|
-          source.message do |message|
+          source.message do |name, message|
             message.must_equal "hello world\nplop"
             source.close
             EM.stop
@@ -120,7 +120,7 @@ describe EventMachine::EventSource do
 
       it "ignore empty message" do
         start_source do |source, req|
-          source.message do |message|
+          source.message do |name, message|
             message.must_equal "hello world"
             EM.stop
           end


### PR DESCRIPTION
The current source code will drop messages which are named, but do not have a name-specific handler installed.  This means that unexpected (but named) messages will be missed, and also prevents the registration of an 'else' or 'fallback' handler.

I propose that either source.message handlers receive all messages which do not have a name-specific handler registered - or - they receive all messages globally, and the name specific handlers are then called an additional time for each match.

The patch here implements the former.
