### PR TITLE
middleware: fix exceptions on reconnections

### DIFF
--- a/lib/em-eventsource.rb
+++ b/lib/em-eventsource.rb
@@ -88,7 +88,8 @@ module EventMachine
     #
     # Returns nothing
     def use(*args, &block)
-      @middlewares << (args << block)
+      block = args.pop if block.nil? && block_given?
+      @middlewares << [args, block]
     end
 
     # Start subscription
@@ -179,9 +180,12 @@ module EventMachine
 
     def prepare_request
       conn = EM::HttpRequest.new(@url, :inactivity_timeout => @inactivity_timeout)
-      @middlewares.each { |middleware|
-        block = middleware.pop
-        conn.use(*middleware, &block)
+      @middlewares.each { |middleware, block|
+        if block
+          conn.use(*middleware, &block)
+        else
+          conn.use(*middleware)
+        end
       }
       headers = @headers.merge({'Cache-Control' => 'no-cache', 'Accept' => 'text/event-stream'})
       headers.merge!({'Last-Event-Id' => @last_event_id }) if not @last_event_id.nil?

--- a/spec/em-eventsource_spec.rb
+++ b/spec/em-eventsource_spec.rb
@@ -206,6 +206,73 @@ describe EventMachine::EventSource do
       req2.middlewares.must_equal [["oup", "la", "boom", proc]]
       EM.stop
     end
+
+    start_source do |source ,req|
+      proc = Proc.new {}
+      source.use "oup", &proc
+      source.close
+      source.start
+      req2 = source.instance_variable_get "@req"
+      req2.middlewares.must_equal [["oup", proc]]
+      EM.stop
+    end
+
+    start_source do |source ,req|
+      proc = Proc.new {}
+      source.use "oup", nil, nil, &proc
+      source.close
+      source.start
+      req2 = source.instance_variable_get "@req"
+      req2.middlewares.must_equal [["oup", nil, nil, proc]]
+      EM.stop
+    end
+
+    start_source do |source ,req|
+      source.use "oup"
+      source.close
+      source.start
+      req2 = source.instance_variable_get "@req"
+      req2.middlewares.must_equal [["oup", nil]]
+      EM.stop
+    end
+
+    start_source do |source ,req|
+      source.use "oup", "la", "boom"
+      source.close
+      source.start
+      req2 = source.instance_variable_get "@req"
+      req2.middlewares.must_equal [["oup", "la", "boom", nil]]
+      EM.stop
+    end
+
+    start_source do |source ,req|
+      source.use("oup", "la", "boom") do
+        true
+      end
+      source.close
+      source.start
+      req2 = source.instance_variable_get "@req"
+      req2.middlewares.size.must_equal 1
+      req2.middlewares[0].size.must_equal 4
+      req2.middlewares[0][0..2].must_equal ["oup", "la", "boom"]
+      req2.middlewares[0][3].class.must_equal Proc
+      EM.stop
+    end
+  end
+
+  it "keeps connection middlewares calls the same" do
+    start_source do |source ,req|
+      source.use "Keep", "me", "equal"
+      source.close
+      source.start
+      req2 = source.instance_variable_get "@req"
+      req2.middlewares.must_equal [["Keep", "me", "equal", nil]]
+      source.close
+      source.start
+      req2 = source.instance_variable_get "@req"
+      req2.middlewares.must_equal [["Keep", "me", "equal", nil]]
+      EM.stop
+    end
   end
 
   it "allows to set the inactivity_timeout" do


### PR DESCRIPTION
The use of Array#pop modifies the middleware calls on the code by removing the last argument of the call. If the connection never failed this wouldn't be a problem, but when it did the second call to the middleware would be different, missing the last argument.
