### PR TITLE
Force UTF-8 encoding on incoming events

### DIFF
--- a/lib/em-eventsource.rb
+++ b/lib/em-eventsource.rb
@@ -117,6 +117,9 @@ module EventMachine
       @req.callback(&method(:handle_reconnect))
       buffer = ""
       @req.stream do |chunk|
+        unless chunk.valid_encoding?
+          chunk.scrub!('?')
+        end
         buffer += chunk
         while index = buffer.index(/\r\n\r\n|\n\n/)
           stream = buffer.slice!(0..index)

--- a/spec/em-eventsource_spec.rb
+++ b/spec/em-eventsource_spec.rb
@@ -154,6 +154,17 @@ describe EventMachine::EventSource do
         end
       end
 
+      it "removes characters that are not UTF-8" do
+        start_source do |source, req|
+          source.message do |message|
+            message.must_equal "foo?bar"
+            source.close
+            EM.stop
+          end
+          req.stream_data("data: foo\xE4bar#{eol}#{eol}")
+        end
+      end
+
       it "handle event name" do
         start_source do |source, req|
           source.on "plop" do |message|


### PR DESCRIPTION
If the "chunk" contains characters that aren't UTF-8, the library will fail with "invalid byte sequence in UTF-8 (ArgumentError)". This patch fixes this and ensures we work only with UTF-8.