### PR TITLE
Add "tls: {verify_peer: true}" to  HttpRequest call

### DIFF
--- a/lib/em-eventsource.rb
+++ b/lib/em-eventsource.rb
@@ -193,7 +193,7 @@ module EventMachine
     end
 
     def prepare_request
-      conn = EM::HttpRequest.new(@url, inactivity_timeout: @inactivity_timeout)
+      conn = EM::HttpRequest.new(@url, {tls: {verify_peer: true}, inactivity_timeout: @inactivity_timeout})
       @middlewares.each do |middleware, block|
         if block
           conn.use(*middleware, &block)


### PR DESCRIPTION
Fixes issue https://github.com/francois2metz/em-eventsource/issues/18

The em-http-request gem recently published a new version (1.1.6) which highlights a CVE around a Man in the Middle attack: igrigorik/em-http-request#339. Is it possible to have the gem use TLS by default?

I am getting this warning when using this gem in various projects:

```
[WARNING; em-http-request] TLS hostname validation is disabled (use 'tls: {verify_peer: true}'), see CVE-2020-13482 and https://github.com/igrigorik/em-http-request/issues/339 for details
```